### PR TITLE
Editing the texts and suggestions for improving structure

### DIFF
--- a/tutorial/westeros/westeros_fossil_resource.ipynb
+++ b/tutorial/westeros/westeros_fossil_resource.ipynb
@@ -4,16 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Westeros Tutorial\n",
-    "## Adding fossil resources - Part 1\n",
+    "# Westeros Tutorial Part 3a- Adding fossil resources (i)\n",
     "\n",
-    "In this tutorial we will cover the addition of fossil resources, i.e. resource supply curves, to the model.  This will include defining a `resource_volume` and respective costs.  Multiple resource categories can be added for a single commodity, allowing, for example, a differentiation to be made between '*reserves*' and '*resources*' and/or the location of the resources, i.e. above or below ground; on- or off-shore.\n",
+    "This tutorial shows how to add fossil fuel resources in the form of resource supply curves to a MESSAGEix scenario. This includes defining `resource_volume` and `resource_cost`. Multiple resource categories can be added for a single commodity like coal, allowing, for example, a differentiation between '*reserves*' and '*resources*', the quality, or location of the resources, i.e., above or below ground, or on- or off-shore.\n",
     "\n",
+    "## Difference between reserves and resources\n",
     "‘*Reserves*’ are generally defined as being those quantities for which geological and engineering information indicate with reasonable certainty that they can be recovered in the future from known reservoirs under existing economic and operating conditions. ‘*Resources*’ are detected quantities that cannot be profitably recovered with current technology, but might be recoverable in the future, as well as those quantities that are geologically possible, but yet to be found. Definitions are based on Rogner et al. (2012). \n",
     "\n",
-    "In this tutorial, we will be adding two categories of coal resources.  The assumed potential is based on the coal requirements by the `coal_ppl` in the baseline, and will be split so that we can also observe the use of multiple resource categories. \n",
+    "In this tutorial, we add two categories of coal resources. We assume a resource potential based on the coal requirements by the `coal_ppl` in the baseline scenario. We also show the use of multiple resource categories. \n",
     "\n",
-    "Two further tutorials on adding fossil resources are available, which will elaborate on the modelling of fossil resources. Part 2 will introduce the constraint `resource_remaining`, therefore specifying what share of these resources must be preserved over time.  In Part 3, we will further add a coal extraction technology, linking the coal resources to the primary energy level, which can be used to model energy requirements of the extraction process."
+    "Two further tutorials on adding fossil resources are available, which will elaborate on the modelling of fossil resources. Part (ii) will introduce the constraint `resource_remaining`, for specifying what share of these resources must be preserved over time.  In Part (iii), we will further add a coal extraction technology, linking the coal resources to the primary energy level, which can be used to model energy requirements of the extraction process."
    ]
   },
   {
@@ -22,6 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Importing required software packages\n",
     "import pandas as pd\n",
     "import ixmp\n",
     "import message_ix\n",
@@ -37,6 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Loading modeling platform\n",
     "mp = ixmp.Platform()"
    ]
   },
@@ -44,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load the existing scenario '*baseline*' and clone to a new scenario '*renewable_potential*' to which we will apply the `renewable_resource_constraints` constraint"
+    "## Making a clone of the existing scenario '*baseline*'"
    ]
   },
   {
@@ -55,6 +57,7 @@
    "source": [
     "model = 'Westeros Electrified'\n",
     "base = message_ix.Scenario(mp, model=model, scenario='baseline')\n",
+    "# Cloning with a new scenario name 'fossil_resources'\n",
     "scen = base.clone(model, 'fossil_resources', 'illustration of adding fossil resources', keep_solution=False)\n",
     "scen.check_out()"
    ]
@@ -63,64 +66,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Retrieve parameters to perform subsequent addition of parameters and define 'base' dataframes for adding parameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "year_df = scen.vintage_and_active_years()\n",
-    "vintage_years, act_years = year_df['year_vtg'], year_df['year_act']\n",
-    "model_horizon = scen.set('year')\n",
-    "country = 'Westeros'\n",
-    "\n",
-    "base_input = {\n",
-    "    'node_loc': country,\n",
-    "    'year_vtg': vintage_years\n",
-    "    ,\n",
-    "    'year_act': act_years,\n",
-    "    'mode': 'standard',\n",
-    "    'node_origin': country,\n",
-    "    'commodity': 'electricity',\n",
-    "    'time': 'year',\n",
-    "    'time_origin': 'year',\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## `resource_potential` and `grade`- Describing the fossil resource potentials\n",
+    "## Resource potentials in MESSAGEix\n",
     "\n",
     "Introducing fossil resources requires the following steps to be carried out:\n",
     "1. Add level and commodity required for resources:\n",
-    "   - Specify the new level and commodity which accounts for the coal resources.\n",
-    "   - Specify which level is a `resource`\n",
-    "2. Add potentials and corresponding parameters\n",
-    "   - Add `grade`\n",
-    "   - Add `resource_volume`\n",
-    "   - Add `resource_cost`\n",
-    "   - Add `historical_extraction`\n",
-    "3. Modify existing `coal_ppl` technology by adding a new `input` parameter."
+    "   - Defining a new level and commodity which accounts for the coal resources.\n",
+    "   - Specifying this level as `resource`\n",
+    "\n",
+    "\n",
+    "2. Add resource potentials and corresponding parameters, including:\n",
+    "   - `grade`\n",
+    "   - `resource_volume`\n",
+    "   - `resource_cost`\n",
+    "   - `historical_extraction`\n",
+    "\n",
+    "\n",
+    "3. Linking the existing `coal_ppl` technology to the relevant resource, by updating the `input` parameter."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the '*baseline*' scenario we know that the `coal_ppl` required 3942 GWa of coal.  We will set the potentials so that sufficient coal is available for use bu the `coal_ppl`. A parameter `historical_extraction` is also introduced purly for demonstation purposes, although this will not impact the `resource_potentials`, i.e. `historical_extraction` is disregarded in the equation 'RESOURCE_CONSTRAINT'. Therefore, the potentials added will always reflect the resource availability as of the `firstmodelyear`.\n",
-    "NOTE: When cloning a scenario and shifting the firstmodelyear, the `resource_volume` will be automatically adjusted to reflected the amounts previously used."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Add coal resources"
+    "### 1. Defining level, grade, and commodity\n",
+    "We define two grades *a and b* for coal resources. Later, we define different costs for these grades."
    ]
   },
   {
@@ -129,7 +98,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# {grade: [volume, cost, share remaining, historical_extraction]}\n",
+    "# Adding required information via MESSAGEix sets\n",
+    "commodity= 'coal'\n",
+    "level = 'resource'\n",
+    "scen.add_set('commodity', commodity)\n",
+    "scen.add_set('level', level)\n",
+    "scen.add_set('level_resource', level)\n",
+    "scen.add_set('grade', ['a', 'b'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Setting up parameters\n",
+    "Based on the coal use in the *baseline* scenario, we set a sufficient potential for coal resources to be used by `coal_ppl`. In real examples, the amount of resources can be limited, which will be one of the criteria for employing different technologies. We update parameter `historical_extraction`, though it is not used in this tutorial. We show this as it can be useful when there is a history of resource extraction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieving model period information\n",
+    "year_df = scen.vintage_and_active_years()\n",
+    "vintage_years, act_years = year_df['year_vtg'], year_df['year_act']\n",
+    "model_horizon = scen.set('year')\n",
+    "country = 'Westeros'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Information for each \"grade\" including, potential, remaining share, historical extraction:\n",
     "potentials = {'a': [1000, 1.0, 280],\n",
     "              'b': [2942, 6.0, 0]}"
    ]
@@ -140,22 +145,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "commodity= 'coal'\n",
-    "level = 'resource'\n",
-    "scen.add_set('commodity', commodity)\n",
-    "scen.add_set('level', level)\n",
-    "scen.add_set('level_resource', level)\n",
-    "for grade in potentials:\n",
-    "    scen.add_set('grade', grade)\n",
-    "    # index for resource_volume is ['node', 'commodity', 'grade', 'value', 'unit']\n",
+    "# Adding required information via MESSAGEix sets\n",
+    "for grade in potentials.keys():\n",
+    "\n",
+    "    # Adding resource potentials\n",
+    "    # The index sets for resource_volume are ['node', 'commodity', 'grade', 'value', 'unit']\n",
     "    df = pd.DataFrame({'node': [country],\n",
     "                       'commodity': commodity,\n",
     "                       'grade': grade,\n",
     "                       'value': potentials[grade][0],\n",
     "                       'unit': 'GWa'})\n",
     "    scen.add_par('resource_volume', df)\n",
-    "       \n",
-    "    # index for resouce_cost is ['node', 'commodity', 'grade', 'year', 'value', 'unit']\n",
+    "    \n",
+    "    # Adding resource costs\n",
+    "    # The index sets for resource_cost are ['node', 'commodity', 'grade', 'year', 'value', 'unit']\n",
     "    df = pd.DataFrame({'node': country,\n",
     "                       'commodity': commodity,\n",
     "                       'grade': grade,\n",
@@ -164,7 +167,8 @@
     "                       'unit': 'GWa'})\n",
     "    scen.add_par('resource_cost', df)\n",
     "    \n",
-    "    # index for historical_extraction is ['node', 'commodity', 'grade', 'year', 'value', 'unit']\n",
+    "    # Adding historical extraction\n",
+    "    # The index sets for historical_extraction are ['node', 'commodity', 'grade', 'year', 'value', 'unit']\n",
     "    df = pd.DataFrame({'node': country,\n",
     "                       'commodity': commodity,\n",
     "                       'grade': grade,\n",
@@ -178,7 +182,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Adjust `coal_ppl` parameter `input` to establish link to the resources"
+    "### 3. Linking `coal_ppl` to resources through `input` parameter"
    ]
   },
   {
@@ -187,8 +191,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# A base dataframe for \"input\" parameter\n",
+    "base_input = {\n",
+    "    'node_loc': country,\n",
+    "    'year_vtg': vintage_years\n",
+    "    ,\n",
+    "    'year_act': act_years,\n",
+    "    'mode': 'standard',\n",
+    "    'node_origin': country,\n",
+    "    'commodity': 'electricity',\n",
+    "    'time': 'year',\n",
+    "    'time_origin': 'year',\n",
+    "}\n",
+    "\n",
     "df = make_df(base_input, technology='coal_ppl', commodity='coal', \n",
     "                   level='resource', value=1, unit='%')\n",
+    "\n",
     "scen.add_par('input', df)"
    ]
   },
@@ -374,7 +392,7 @@
    "source": [
     "## Extraction\n",
     "***\n",
-    "Looking at the extraction over time, we can see that the model uses up the available potential of the cheaper `grade a` early on.  The switch to the more expensive `grade b` as of 710, is the reason for the price increase of `light`."
+    "Looking at the extraction over time, we can see that the model uses up the available potential of the cheaper `grade` *a* early on. The switch to the more expensive `grade` *b* as of 710 is the reason for the increase in the price of `light`."
    ]
   },
   {
@@ -419,7 +437,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR suggests some edits and changes to improve the original PR.
Thanks @OFR-IIASA for the interesting tutorial. I suggest the following changes:
- The title of new tutorials should follow the logic and format of the existing ones.
- The description in the beginning can be shortened. For example, if the part related to the difference between reserves and resources will be removed has no impact on the tutorial.
- A graph for showing resource grades (supply curve) can be useful and illustrative.
- Important: the results of this tutorial for activity of coal_ppl is now very different from baseline. Is this intended? If yes, please consider mentioning the reason when comparing the results with the baseline.

I did the following:
- Long section titles were shortened. 
- Text were updated and shortened in some parts.
- Sections organized for following the three steps laid out in the tutorial.
